### PR TITLE
Updates the yasgui files to protect against xss

### DIFF
--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -24,8 +24,8 @@
 
 
     <!-- YASGUI -->
-    <link href="https://unpkg.com/@triply/yasgui/build/yasgui.min.css" rel="stylesheet" type="text/css" />
-    <script src="https://unpkg.com/@triply/yasgui/build/yasgui.min.js"></script>
+    <link href="https://unpkg.com/@zazuko/yasgui@4.2.32/build/yasgui.min.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/@zazuko/yasgui@4.2.32/build/yasgui.min.js"></script>
 
 
     <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
We want to update this because it came up as an issue in our penetration test.

This is the new repo https://github.com/zazuko/Yasgui which includes pull requests for issues on the old repo for XSS
https://github.com/TriplyDB/Yasgui/issues?q=is%3Aissue+is%3Aopen+xss